### PR TITLE
Make language definitions self-contained.

### DIFF
--- a/lib/coursemology/polyglot.rb
+++ b/lib/coursemology/polyglot.rb
@@ -6,6 +6,7 @@ module Coursemology::Polyglot
 
   eager_autoload do
     autoload :Language
+    autoload :ConcreteLanguage
   end
 
   def self.eager_load!

--- a/lib/coursemology/polyglot/concrete_language.rb
+++ b/lib/coursemology/polyglot/concrete_language.rb
@@ -1,0 +1,9 @@
+# This module is included when a Language can be directly used by the user.
+#
+# This is deliberately defined so that consumers of this library can inject methods into all
+# concrete languages.
+module Coursemology::Polyglot::ConcreteLanguage
+  extend ActiveSupport::Autoload
+
+  autoload :ClassMethods
+end

--- a/lib/coursemology/polyglot/concrete_language/class_methods.rb
+++ b/lib/coursemology/polyglot/concrete_language/class_methods.rb
@@ -1,0 +1,7 @@
+# This module is extended by the language's singleton class when the Language can be directly used
+# by the user.
+#
+# This is deliberately defined so that consumers of this library can inject methods into all
+# concrete languages' classes.
+module Coursemology::Polyglot::ConcreteLanguage::ClassMethods
+end

--- a/lib/coursemology/polyglot/language.rb
+++ b/lib/coursemology/polyglot/language.rb
@@ -8,11 +8,50 @@ else
   class Coursemology::Polyglot::Language; end
 end
 
+# An abstract language. This is a class which can represent a family of languages. Languages become
+# concrete and can be used when that language includes +Coursemology::Polyglot::ConcreteLanguage+.
+#
+# Languages define their own scripts and stylesheets needed to syntax highlight code.
+#
+# Each subclass represents a language ancestry, such as differing language versions (see the Python
+# language definition.) Derived languages can be defined at runtime to utilise the syntax
+# highlighting capabilities of the root language, while requiring a separate runtime environment to
+# run programs written in the derived language.
+#
+# Do *NOT* remove languages after they have been defined because the types specified in this
+# library can have references stored in code (e.g. in a database)
 class Coursemology::Polyglot::Language
   extend ActiveSupport::Autoload
 
   eager_autoload do
     autoload :Python
+  end
+
+  # Marks the current class as a concrete language.
+  #
+  # Concrete languages can be instantiated and used.
+  #
+  # @param [String] display_name The display name for the language
+  def self.concrete_language(display_name)
+    include Coursemology::Polyglot::ConcreteLanguage
+    extend Coursemology::Polyglot::ConcreteLanguage::ClassMethods
+
+    concrete_class_methods = Module.new do
+      define_method(:display_name) do
+        display_name
+      end
+    end
+
+    extend concrete_class_methods
+  end
+
+  # Determines the concrete language subclasses of this language.
+  #
+  # @return [Array<Class>]
+  def self.concrete_languages
+    descendants.select do |klass|
+      klass.ancestors.include?(Coursemology::Polyglot::ConcreteLanguage)
+    end
   end
 
   # Gets the display name of the language.

--- a/lib/coursemology/polyglot/language/python.rb
+++ b/lib/coursemology/polyglot/language/python.rb
@@ -1,17 +1,9 @@
 class Coursemology::Polyglot::Language::Python < Coursemology::Polyglot::Language
   class Python2Point7 < Coursemology::Polyglot::Language::Python
-    class << self
-      def display_name
-        'Python 2.7'
-      end
-    end
+    concrete_language 'Python 2.7'
   end
 
   class Python3Point4 < Coursemology::Polyglot::Language::Python
-    class << self
-      def display_name
-        'Python 3.4'
-      end
-    end
+    concrete_language 'Python 3.4'
   end
 end

--- a/spec/coursemology/polyglot/language_spec.rb
+++ b/spec/coursemology/polyglot/language_spec.rb
@@ -1,6 +1,42 @@
 require 'spec_helper'
 
 RSpec.describe Coursemology::Polyglot::Language do
+  class self::AbstractLanguage < Coursemology::Polyglot::Language
+  end
+
+  class self::DummyLanguage < self::AbstractLanguage
+    DISPLAY_NAME = 'Dummy 0.1'
+    concrete_language DISPLAY_NAME
+  end
+
+  describe '.concrete_language' do
+    it 'sets the correct display name' do
+      expect(self.class::DummyLanguage.display_name).to eq(self.class::DummyLanguage::DISPLAY_NAME)
+    end
+
+    it 'includes Coursemology::Polyglot::ConcreteLanguage' do
+      expect(self.class::DummyLanguage.new).to \
+        be_a_kind_of(Coursemology::Polyglot::ConcreteLanguage)
+    end
+
+    it 'extends Coursemology::Polyglot::ConcreteLanguage::ClassMethods' do
+      expect(self.class::DummyLanguage).to \
+        be_a_kind_of(Coursemology::Polyglot::ConcreteLanguage::ClassMethods)
+    end
+  end
+
+  describe '.concrete_languages' do
+    it 'returns a language declared as concrete' do
+      expect(Coursemology::Polyglot::Language.concrete_languages).to \
+        include(self.class::DummyLanguage)
+    end
+
+    it 'does not return subclasses not declared as concrete' do
+      expect(Coursemology::Polyglot::Language.concrete_languages).not_to \
+        include(self.class::AbstractLanguage)
+    end
+  end
+
   describe '.display_name' do
     it 'fails with NotImplementedError' do
       expect { subject.class.display_name }.to raise_error(NotImplementedError)


### PR DESCRIPTION
For comments first, not squashed