### PR TITLE
Fix the name of the Python images to use Docker tags.

### DIFF
--- a/lib/coursemology/polyglot/language/python.rb
+++ b/lib/coursemology/polyglot/language/python.rb
@@ -1,9 +1,9 @@
 class Coursemology::Polyglot::Language::Python < Coursemology::Polyglot::Language
   class Python2Point7 < Coursemology::Polyglot::Language::Python
-    concrete_language 'Python 2.7'
+    concrete_language 'Python 2.7', docker_image: 'python:2.7'
   end
 
   class Python3Point4 < Coursemology::Polyglot::Language::Python
-    concrete_language 'Python 3.4'
+    concrete_language 'Python 3.4', docker_image: 'python:3.4'
   end
 end


### PR DESCRIPTION
See https://hub.docker.com/r/coursemology/evaluator-image-python/

After this I'll push coursemology-polyglot v0.0.3