### PR TITLE
Implement a `syntax_highlighter` directive for languages.

### DIFF
--- a/lib/coursemology/polyglot/language.rb
+++ b/lib/coursemology/polyglot/language.rb
@@ -46,6 +46,7 @@ class Coursemology::Polyglot::Language
 
     extend concrete_class_methods
   end
+  private_class_method :concrete_language
 
   # Determines the concrete language subclasses of this language.
   #
@@ -56,6 +57,31 @@ class Coursemology::Polyglot::Language
     end
   end
 
+  # The name of the lexer or mode to use with a given library. This is inherited by classes.
+  #
+  # @param [String|nil] default The default lexer/mode to use for each library.
+  # @param [String] rouge The overridden lexer to use for Rouge. This is optional and will
+  #   default to +default+
+  # @param [String] ace The overridden mode to use for Ace. This is optional and will
+  #   default to +default+
+  # @raise [ArgumentError] When no default is specified and the Rouge lexer or Ace mode is not
+  #   specified.
+  def self.syntax_highlighter(default = nil, rouge: default, ace: default)
+    fail ArgumentError unless rouge && ace
+
+    syntax_highlighter_class_methods = Module.new do
+      define_method(:rouge_lexer) { rouge }
+      define_method(:ace_mode) { ace }
+    end
+    extend syntax_highlighter_class_methods
+
+    syntax_highlighter_instance_methods = Module.new do
+      delegate :rouge_lexer, :ace_mode, to: :class
+    end
+    include syntax_highlighter_instance_methods
+  end
+  private_class_method :syntax_highlighter
+
   # Gets the display name of the language.
   #
   # @abstract
@@ -64,23 +90,19 @@ class Coursemology::Polyglot::Language
     fail NotImplementedError
   end
 
-  # The stylesheets that need to be packaged with the rest of the application.
-  #
-  # This should include the Rouge/Pygments stylesheet for formatting code.
+  # The Rouge lexer to use with this language.
   #
   # @abstract
-  # @return [Array<String>]
-  def self.stylesheets
+  # @return [String]
+  def self.rouge_lexer
     fail NotImplementedError
   end
 
-  # The script files that need to be packaged with the rest of the application.
-  #
-  # This should include the Ace mode for the language.
+  # The Ace mode to use with this language.
   #
   # @abstract
-  # @return [Array<String>]
-  def self.javascript
+  # @return [String]
+  def self.ace_mode
     fail NotImplementedError
   end
 end

--- a/lib/coursemology/polyglot/language/python.rb
+++ b/lib/coursemology/polyglot/language/python.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 class Coursemology::Polyglot::Language::Python < Coursemology::Polyglot::Language
+  syntax_highlighter 'python'
+
   class Python2Point7 < Coursemology::Polyglot::Language::Python
     concrete_language 'Python 2.7', docker_image: 'python:2.7'
   end

--- a/spec/coursemology/polyglot/language_spec.rb
+++ b/spec/coursemology/polyglot/language_spec.rb
@@ -57,21 +57,97 @@ RSpec.describe Coursemology::Polyglot::Language do
     end
   end
 
+  describe '.syntax_highlighter' do
+    context 'when a default is given' do
+      context 'when nothing is explicit specified' do
+        class self::SyntaxHighlighterTestClass < Coursemology::Polyglot::Language
+          MODE = 'test'.freeze
+          syntax_highlighter MODE
+        end
+
+        subject { self.class::SyntaxHighlighterTestClass }
+        it 'uses the argument for Rouge' do
+          expect(subject.rouge_lexer).to eq(subject::MODE)
+        end
+
+        it 'uses the argument for Ace' do
+          expect(subject.ace_mode).to eq(subject::MODE)
+        end
+      end
+
+      context 'when rouge is explicitly specified' do
+        class self::SyntaxHighlighterTestClass < Coursemology::Polyglot::Language
+          MODE = 'test'.freeze
+          ROUGE_LEXER = 'rouge'.freeze
+          syntax_highlighter MODE, rouge: ROUGE_LEXER
+        end
+
+        subject { self.class::SyntaxHighlighterTestClass }
+        it 'uses the argument for Rouge' do
+          expect(subject.rouge_lexer).to eq(subject::ROUGE_LEXER)
+        end
+
+        it 'uses the default for Ace' do
+          expect(subject.ace_mode).to eq(subject::MODE)
+        end
+      end
+
+      context 'when Ace is explicitly specified' do
+        class self::SyntaxHighlighterTestClass < Coursemology::Polyglot::Language
+          MODE = 'test'.freeze
+          ACE_MODE = 'ace'.freeze
+          syntax_highlighter MODE, ace: ACE_MODE
+        end
+
+        subject { self.class::SyntaxHighlighterTestClass }
+        it 'uses the default for Rouge' do
+          expect(subject.rouge_lexer).to eq(subject::MODE)
+        end
+
+        it 'uses the argument for Ace' do
+          expect(subject.ace_mode).to eq(subject::ACE_MODE)
+        end
+      end
+    end
+
+    context 'when no default is given' do
+      context 'when no explicit Rouge lexer is specified' do
+        it 'raises an ArgumentError' do
+          expect do
+            class self.class::SyntaxHighlighterTestClass < Coursemology::Polyglot::Language
+              syntax_highlighter ace: 'test'
+            end
+          end.to raise_error(ArgumentError)
+        end
+      end
+
+      context 'when no explicit Ace mode is specified' do
+        it 'raises an ArgumentError' do
+          expect do
+            class self.class::SyntaxHighlighterTestClass < Coursemology::Polyglot::Language
+              syntax_highlighter rouge: 'test'
+            end
+          end.to raise_error(ArgumentError)
+        end
+      end
+    end
+  end
+
   describe '.display_name' do
     it 'fails with NotImplementedError' do
       expect { subject.class.display_name }.to raise_error(NotImplementedError)
     end
   end
 
-  describe '.stylesheets' do
+  describe '.rouge_lexer' do
     it 'fails with NotImplementedError' do
-      expect { subject.class.stylesheets }.to raise_error(NotImplementedError)
+      expect { subject.class.rouge_lexer }.to raise_error(NotImplementedError)
     end
   end
 
-  describe '.javascript' do
+  describe '.ace_mode' do
     it 'fails with NotImplementedError' do
-      expect { subject.class.javascript }.to raise_error(NotImplementedError)
+      expect { subject.class.ace_mode }.to raise_error(NotImplementedError)
     end
   end
 end


### PR DESCRIPTION
This allows languages to specify which Rouge lexer and Ace mode to use with.