### PR TITLE
Fix syntax highlighting declaration for CPlusPlus.

### DIFF
--- a/lib/coursemology/polyglot/language/c_plus_plus.rb
+++ b/lib/coursemology/polyglot/language/c_plus_plus.rb
@@ -1,4 +1,4 @@
 class Coursemology::Polyglot::Language::CPlusPlus < Coursemology::Polyglot::Language
-  syntax_highlighter 'cpp'
+  syntax_highlighter 'cpp', ace: 'c_cpp'
   concrete_language 'C/C++', docker_image: 'c_cpp'
 end

--- a/lib/coursemology/polyglot/version.rb
+++ b/lib/coursemology/polyglot/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 module Coursemology; end
 module Coursemology::Polyglot
-  VERSION = '0.2.6'.freeze
+  VERSION = '0.2.7'.freeze
 end


### PR DESCRIPTION
Rouge lexer and ace editor use different declarations for cpp.
Bump version to 0.2.7.