### PR TITLE
Bump Rails version to < 5.2

### DIFF
--- a/coursemology-polyglot.gemspec
+++ b/coursemology-polyglot.gemspec
@@ -28,9 +28,9 @@ programming languages supported in Coursemology.
   spec.add_development_dependency 'coveralls'
   spec.add_development_dependency 'codeclimate-test-reporter'
 
-  spec.add_dependency 'activesupport', '>= 4.2', '<= 5.1'
+  spec.add_dependency 'activesupport', '>= 4.2', '< 5.2'
 
   # For autoloading in Rails applications, as well as the Ace modes inclusion. Keep this as the
   # same as ActiveSupport version.
-  spec.add_development_dependency 'railties', '>= 4.2', '<= 5.1'
+  spec.add_development_dependency 'railties', '>= 4.2', '< 5.2'
 end

--- a/lib/coursemology/polyglot/version.rb
+++ b/lib/coursemology/polyglot/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 module Coursemology; end
 module Coursemology::Polyglot
-  VERSION = '0.2.9.1'
+  VERSION = '0.2.9.2'
 end


### PR DESCRIPTION
'<= 5.1' only allows '5.1.0' and not '>= 5.1.1'