### PR TITLE
feat(language-dependencies): add language dependency information

### DIFF
--- a/lib/coursemology/polyglot/language.rb
+++ b/lib/coursemology/polyglot/language.rb
@@ -46,6 +46,18 @@ class Coursemology::Polyglot::Language
     concrete_class_methods = Module.new do
       define_method(:display_name) { display_name }
       define_method(:docker_image) { docker_image }
+
+      define_method(:dependencies) { instance_variable_get('@dependencies') }
+      define_method(:has_dependency) do |name, version:, title: nil, aliases: [], href: nil|
+        fail ArgumentError unless !name.nil? && !version.nil?
+        instance_variable_set('@dependencies', (instance_variable_get('@dependencies') || []) + [{
+          name: name,
+          version: version,
+          title: title,
+          aliases: aliases,
+          href: href
+        }]) 
+      end
     end
 
     extend concrete_class_methods

--- a/lib/coursemology/polyglot/language/c_plus_plus.rb
+++ b/lib/coursemology/polyglot/language/c_plus_plus.rb
@@ -4,12 +4,21 @@ class Coursemology::Polyglot::Language::CPlusPlus < Coursemology::Polyglot::Lang
   syntax_highlighter 'cpp', ace: 'c_cpp'
   concrete_language 'C/C++', docker_image: 'c_cpp:legacy'
 
+  has_dependency 'boost', version: '1.64.0', href: 'https://www.boost.org/'
+  has_dependency 'googletest', version: '1.8.0-642-g3f0cf6b6', href: 'https://github.com/google/googletest'
+
   class CPlusPlus11 < Coursemology::Polyglot::Language::CPlusPlus
     concrete_language 'C++ 11', docker_image: 'c_cpp:11'
+
+    has_dependency 'boost', version: '1.64.0', href: 'https://www.boost.org/'
+    has_dependency 'googletest', version: '1.8.1-712-g565f1b84', href: 'https://github.com/google/googletest'
   end
 
   class CPlusPlus17 < Coursemology::Polyglot::Language::CPlusPlus
     concrete_language 'C++ 17', docker_image: 'c_cpp:17'
+
+    has_dependency 'boost', version: '1.87.0', href: 'https://www.boost.org/'
+    has_dependency 'googletest', version: '1.14.0-171-gf3c355f9', href: 'https://github.com/google/googletest'
   end
 
 end

--- a/lib/coursemology/polyglot/language/java.rb
+++ b/lib/coursemology/polyglot/language/java.rb
@@ -3,17 +3,25 @@ class Coursemology::Polyglot::Language::Java < Coursemology::Polyglot::Language
 
   class Java8 < Coursemology::Polyglot::Language::Java
     concrete_language 'Java 8', docker_image: 'java:8'
+    has_dependency 'jcommander', version: '1.72', href: 'https://jcommander.org'
+    has_dependency 'testng', version: '6.11', href: 'https://testng.org'
   end
 
   class Java11 < Coursemology::Polyglot::Language::Java
     concrete_language 'Java 11', docker_image: 'java:11'
+    has_dependency 'jcommander', version: '1.72', href: 'https://jcommander.org'
+    has_dependency 'testng', version: '6.11', href: 'https://testng.org'
   end
 
   class Java17 < Coursemology::Polyglot::Language::Java
     concrete_language 'Java 17', docker_image: 'java:17'
+    has_dependency 'jcommander', version: '1.72', href: 'https://jcommander.org'
+    has_dependency 'testng', version: '6.11', href: 'https://testng.org'
   end
 
   class Java21 < Coursemology::Polyglot::Language::Java
     concrete_language 'Java 21', docker_image: 'java:21'
+    has_dependency 'jcommander', version: '1.72', href: 'https://jcommander.org'
+    has_dependency 'testng', version: '6.11', href: 'https://testng.org'
   end
 end

--- a/lib/coursemology/polyglot/language/python.rb
+++ b/lib/coursemology/polyglot/language/python.rb
@@ -4,33 +4,91 @@ class Coursemology::Polyglot::Language::Python < Coursemology::Polyglot::Languag
 
   class Python2Point7 < Coursemology::Polyglot::Language::Python
     concrete_language 'Python 2.7', docker_image: 'python:2.7'
+    has_dependency 'timeout-decorator', version: '0.4.1', href: 'https://pypi.org/project/timeout-decorator/'
   end
 
   class Python3Point4 < Coursemology::Polyglot::Language::Python
     concrete_language 'Python 3.4', docker_image: 'python:3.4'
+    has_dependency 'timeout-decorator', version: '0.4.1', href: 'https://pypi.org/project/timeout-decorator/'
   end
 
   class Python3Point5 < Coursemology::Polyglot::Language::Python
     concrete_language 'Python 3.5', docker_image: 'python:3.5'
+    has_dependency 'timeout-decorator', version: '0.4.1', href: 'https://pypi.org/project/timeout-decorator/'
   end
 
   class Python3Point6 < Coursemology::Polyglot::Language::Python
     concrete_language 'Python 3.6', docker_image: 'python:3.6'
+
+    has_dependency 'matplotlib', version: '3.0.3', aliases: ['plt'], href: 'https://matplotlib.org'
+    has_dependency 'numpy', version: '1.16.2', aliases: ['np'], href: 'https://numpy.org'
+    has_dependency 'pandas', version: '0.24.1', aliases: ['pd'], href: 'https://pandas.pydata.org/docs/'
+    has_dependency 'pillow', version: '5.4.1', href: 'https://pillow.readthedocs.io'
+    has_dependency 'scipy', version: '1.2.1', aliases: ['sp'], href: 'https://docs.scipy.org/doc/scipy/'
+    has_dependency 'timeout-decorator', version: '0.4.1', href: 'https://pypi.org/project/timeout-decorator/'
   end
 
   class Python3Point7 < Coursemology::Polyglot::Language::Python
     concrete_language 'Python 3.7', docker_image: 'python:3.7'
+
+    has_dependency 'matplotlib', version: '3.1.1', aliases: ['plt'], href: 'https://matplotlib.org'
+    has_dependency 'numpy', version: '1.17.2', aliases: ['np'], href: 'https://numpy.org'
+    has_dependency 'pandas', version: '0.25.1', aliases: ['pd'], href: 'https://pandas.pydata.org/docs/'
+    has_dependency 'pillow', version: '6.1.0', href: 'https://pillow.readthedocs.io'
+    has_dependency 'scikit-learn', version: '0.21.3', aliases: ['sklearn'], href: 'https://scikit-learn.org'
+    has_dependency 'scipy', version: '1.3.1', aliases: ['sp'], href: 'https://docs.scipy.org/doc/scipy/'
+    has_dependency 'timeout-decorator', version: '0.4.1', href: 'https://pypi.org/project/timeout-decorator/'
+    has_dependency 'torch', version: '1.2.0+cpu', title: 'pytorch', href: 'https://pytorch.org/docs'
+    has_dependency 'torchvision', version: '0.4.0+cpu', aliases: ['tv'], href: 'https://pytorch.org/vision'
   end
 
   class Python3Point9 < Coursemology::Polyglot::Language::Python
     concrete_language 'Python 3.9', docker_image: 'python:3.9'
+
+    has_dependency 'fnss', version: '0.9.1', href: 'https://fnss.readthedocs.io'
+    has_dependency 'matplotlib', version: '3.5.1', aliases: ['plt'], href: 'https://matplotlib.org'
+    has_dependency 'networkx', version: '2.7.1', aliases: ['nx'], href: 'https://networkx.github.io/documentation'
+    has_dependency 'numpy', version: '1.22.3', aliases: ['np'], href: 'https://numpy.org'
+    has_dependency 'pandas', version: '1.4.1', aliases: ['pd'], href: 'https://pandas.pydata.org/docs/'
+    has_dependency 'pillow', version: '9.0.1', href: 'https://pillow.readthedocs.io'
+    has_dependency 'scikit-learn', version: '1.0.2', aliases: ['sklearn'], href: 'https://scikit-learn.org'
+    has_dependency 'scipy', version: '1.8.0', aliases: ['sp'], href: 'https://docs.scipy.org/doc/scipy/'
+    has_dependency 'timeout-decorator', version: '0.5.0', href: 'https://pypi.org/project/timeout-decorator/'
+    has_dependency 'torch', version: '1.9.0+cpu', title: 'pytorch', href: 'https://pytorch.org/docs'
+    has_dependency 'torchvision', version: '0.10.0+cpu', aliases: ['tv'], href: 'https://pytorch.org/vision'
   end
 
   class Python3Point10 < Coursemology::Polyglot::Language::Python
     concrete_language 'Python 3.10', docker_image: 'python:3.10'
+
+    has_dependency 'fnss', version: '0.9.1', href: 'https://fnss.readthedocs.io'
+    has_dependency 'keras', version: '2.9.0', href: 'https://keras.io/api/'
+    has_dependency 'matplotlib', version: '3.5.3', aliases: ['plt'], href: 'https://matplotlib.org'
+    has_dependency 'networkx', version: '2.8.6', aliases: ['nx'], href: 'https://networkx.github.io/documentation'
+    has_dependency 'numpy', version: '1.23.2', aliases: ['np'], href: 'https://numpy.org'
+    has_dependency 'pandas', version: '1.4.3', aliases: ['pd'], href: 'https://pandas.pydata.org/docs/'
+    has_dependency 'pillow', version: '9.2.0', href: 'https://pillow.readthedocs.io'
+    has_dependency 'scikit-learn', version: '1.1.2', aliases: ['sklearn'], href: 'https://scikit-learn.org'
+    has_dependency 'scipy', version: '1.9.0', aliases: ['sp'], href: 'https://docs.scipy.org/doc/scipy/'
+    has_dependency 'tensorflow-cpu', version: '2.9.2', aliases: ['tf'], href: 'https://www.tensorflow.org/api_docs'
+    has_dependency 'timeout-decorator', version: '0.5.0', href: 'https://pypi.org/project/timeout-decorator/'
+    has_dependency 'torch', version: '1.12.1+cpu', title: 'pytorch', href: 'https://pytorch.org/docs'
+    has_dependency 'torchvision', version: '0.13.1+cpu', aliases: ['tv'], href: 'https://pytorch.org/vision'  
   end
 
   class Python3Point12 < Coursemology::Polyglot::Language::Python
     concrete_language 'Python 3.12', docker_image: 'python:3.12'
+
+    has_dependency 'fnss', version: '0.9.1', href: 'https://fnss.readthedocs.io'
+    has_dependency 'matplotlib', version: '3.8.2', aliases: ['plt'], href: 'https://matplotlib.org'
+    has_dependency 'networkx', version: '3.2.1', aliases: ['nx'], href: 'https://networkx.github.io/documentation'
+    has_dependency 'numpy', version: '1.26.3', aliases: ['np'], href: 'https://numpy.org'
+    has_dependency 'pandas', version: '2.1.4', aliases: ['pd'], href: 'https://pandas.pydata.org/docs/'
+    has_dependency 'pillow', version: '10.2.0', href: 'https://pillow.readthedocs.io'
+    has_dependency 'scikit-learn', version: '1.3.2', aliases: ['sklearn'], href: 'https://scikit-learn.org'
+    has_dependency 'scipy', version: '1.11.4', aliases: ['sp'], href: 'https://docs.scipy.org/doc/scipy/'
+    has_dependency 'timeout-decorator', version: '0.5.0', href: 'https://pypi.org/project/timeout-decorator/'
+    has_dependency 'torch', version: '2.3.0.dev20240107+cpu', title: 'pytorch', href: 'https://pytorch.org/docs'
+    has_dependency 'torchvision', version: '0.18.0.dev20240107+cpu', aliases: ['tv'], href: 'https://pytorch.org/vision'
   end
 end

--- a/lib/coursemology/polyglot/version.rb
+++ b/lib/coursemology/polyglot/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 module Coursemology; end
 module Coursemology::Polyglot
-  VERSION = '0.3.11'.freeze
+  VERSION = '0.4.0'.freeze
 end

--- a/spec/coursemology/polyglot/language/c_plus_plus_spec.rb
+++ b/spec/coursemology/polyglot/language/c_plus_plus_spec.rb
@@ -6,17 +6,41 @@ RSpec.describe Coursemology::Polyglot::Language::CPlusPlus do
     it 'returns the correct display name' do
       expect(subject.class.display_name).to eq('C/C++')
     end
+
+    it 'returns the correct dependency versions' do
+      expect(subject.class.dependencies[0][:name]).to eq('boost')
+      expect(subject.class.dependencies[0][:version]).to eq('1.64.0')
+
+      expect(subject.class.dependencies[1][:name]).to eq('googletest')
+      expect(subject.class.dependencies[1][:version]).to eq('1.8.0-642-g3f0cf6b6')
+    end
   end
 
   describe Coursemology::Polyglot::Language::CPlusPlus::CPlusPlus11 do
     it 'returns the correct display name' do
       expect(subject.class.display_name).to eq('C++ 11')
     end
+
+    it 'returns the correct dependency versions' do
+      expect(subject.class.dependencies[0][:name]).to eq('boost')
+      expect(subject.class.dependencies[0][:version]).to eq('1.64.0')
+
+      expect(subject.class.dependencies[1][:name]).to eq('googletest')
+      expect(subject.class.dependencies[1][:version]).to eq('1.8.1-712-g565f1b84')
+    end
   end
 
   describe Coursemology::Polyglot::Language::CPlusPlus::CPlusPlus17 do
     it 'returns the correct display name' do
       expect(subject.class.display_name).to eq('C++ 17')
+    end
+
+    it 'returns the correct dependency versions' do
+      expect(subject.class.dependencies[0][:name]).to eq('boost')
+      expect(subject.class.dependencies[0][:version]).to eq('1.87.0')
+
+      expect(subject.class.dependencies[1][:name]).to eq('googletest')
+      expect(subject.class.dependencies[1][:version]).to eq('1.14.0-171-gf3c355f9')
     end
   end
 end

--- a/spec/coursemology/polyglot/language/java_spec.rb
+++ b/spec/coursemology/polyglot/language/java_spec.rb
@@ -6,11 +6,27 @@ RSpec.describe Coursemology::Polyglot::Language::Java do
     it 'returns the correct display name' do
       expect(subject.class.display_name).to eq('Java 8')
     end
+
+    it 'returns the correct dependency versions' do
+      expect(subject.class.dependencies[0][:name]).to eq('jcommander')
+      expect(subject.class.dependencies[0][:version]).to eq('1.72')
+
+      expect(subject.class.dependencies[1][:name]).to eq('testng')
+      expect(subject.class.dependencies[1][:version]).to eq('6.11')
+    end
   end
 
   describe Coursemology::Polyglot::Language::Java::Java11 do
     it 'returns the correct display name' do
       expect(subject.class.display_name).to eq('Java 11')
+    end
+
+    it 'returns the correct dependency versions' do
+      expect(subject.class.dependencies[0][:name]).to eq('jcommander')
+      expect(subject.class.dependencies[0][:version]).to eq('1.72')
+
+      expect(subject.class.dependencies[1][:name]).to eq('testng')
+      expect(subject.class.dependencies[1][:version]).to eq('6.11')
     end
   end
 
@@ -18,11 +34,27 @@ RSpec.describe Coursemology::Polyglot::Language::Java do
     it 'returns the correct display name' do
       expect(subject.class.display_name).to eq('Java 17')
     end
+
+    it 'returns the correct dependency versions' do
+      expect(subject.class.dependencies[0][:name]).to eq('jcommander')
+      expect(subject.class.dependencies[0][:version]).to eq('1.72')
+
+      expect(subject.class.dependencies[1][:name]).to eq('testng')
+      expect(subject.class.dependencies[1][:version]).to eq('6.11')
+    end
   end
 
   describe Coursemology::Polyglot::Language::Java::Java21 do
     it 'returns the correct display name' do
       expect(subject.class.display_name).to eq('Java 21')
+    end
+
+    it 'returns the correct dependency versions' do
+      expect(subject.class.dependencies[0][:name]).to eq('jcommander')
+      expect(subject.class.dependencies[0][:version]).to eq('1.72')
+
+      expect(subject.class.dependencies[1][:name]).to eq('testng')
+      expect(subject.class.dependencies[1][:version]).to eq('6.11')
     end
   end
 end

--- a/spec/coursemology/polyglot/language/python_spec.rb
+++ b/spec/coursemology/polyglot/language/python_spec.rb
@@ -6,11 +6,21 @@ RSpec.describe Coursemology::Polyglot::Language::Python do
     it 'returns the correct display name' do
       expect(subject.class.display_name).to eq('Python 2.7')
     end
+
+    it 'returns the correct dependency versions' do
+      expect(subject.class.dependencies[0][:name]).to eq('timeout-decorator')
+      expect(subject.class.dependencies[0][:version]).to eq('0.4.1')
+    end
   end
 
   describe Coursemology::Polyglot::Language::Python::Python3Point4 do
     it 'returns the correct display name' do
       expect(subject.class.display_name).to eq('Python 3.4')
+    end
+
+    it 'returns the correct dependency versions' do
+      expect(subject.class.dependencies[0][:name]).to eq('timeout-decorator')
+      expect(subject.class.dependencies[0][:version]).to eq('0.4.1')
     end
   end
 
@@ -18,11 +28,27 @@ RSpec.describe Coursemology::Polyglot::Language::Python do
     it 'returns the correct display name' do
       expect(subject.class.display_name).to eq('Python 3.5')
     end
+
+    it 'returns the correct dependency versions' do
+      expect(subject.class.dependencies[0][:name]).to eq('timeout-decorator')
+      expect(subject.class.dependencies[0][:version]).to eq('0.4.1')
+    end
   end
 
   describe Coursemology::Polyglot::Language::Python::Python3Point6 do
     it 'returns the correct display name' do
       expect(subject.class.display_name).to eq('Python 3.6')
+    end
+
+    it 'returns the correct dependency versions' do
+      expect(subject.class.dependencies[0][:name]).to eq('matplotlib')
+      expect(subject.class.dependencies[0][:version]).to eq('3.0.3')
+
+      expect(subject.class.dependencies[1][:name]).to eq('numpy')
+      expect(subject.class.dependencies[1][:version]).to eq('1.16.2')
+
+      expect(subject.class.dependencies[2][:name]).to eq('pandas')
+      expect(subject.class.dependencies[2][:version]).to eq('0.24.1')
     end
   end
 
@@ -30,11 +56,33 @@ RSpec.describe Coursemology::Polyglot::Language::Python do
     it 'returns the correct display name' do
       expect(subject.class.display_name).to eq('Python 3.7')
     end
+
+    it 'returns the correct dependency versions' do
+      expect(subject.class.dependencies[0][:name]).to eq('matplotlib')
+      expect(subject.class.dependencies[0][:version]).to eq('3.1.1')
+
+      expect(subject.class.dependencies[1][:name]).to eq('numpy')
+      expect(subject.class.dependencies[1][:version]).to eq('1.17.2')
+
+      expect(subject.class.dependencies[2][:name]).to eq('pandas')
+      expect(subject.class.dependencies[2][:version]).to eq('0.25.1')
+    end
   end
 
   describe Coursemology::Polyglot::Language::Python::Python3Point9 do
     it 'returns the correct display name' do
       expect(subject.class.display_name).to eq('Python 3.9')
+    end
+
+    it 'returns the correct dependency versions' do
+      expect(subject.class.dependencies[0][:name]).to eq('fnss')
+      expect(subject.class.dependencies[0][:version]).to eq('0.9.1')
+
+      expect(subject.class.dependencies[1][:name]).to eq('matplotlib')
+      expect(subject.class.dependencies[1][:version]).to eq('3.5.1')
+
+      expect(subject.class.dependencies[2][:name]).to eq('networkx')
+      expect(subject.class.dependencies[2][:version]).to eq('2.7.1')
     end
   end
 
@@ -42,11 +90,33 @@ RSpec.describe Coursemology::Polyglot::Language::Python do
     it 'returns the correct display name' do
       expect(subject.class.display_name).to eq('Python 3.10')
     end
+
+    it 'returns the correct dependency versions' do
+      expect(subject.class.dependencies[0][:name]).to eq('fnss')
+      expect(subject.class.dependencies[0][:version]).to eq('0.9.1')
+
+      expect(subject.class.dependencies[1][:name]).to eq('keras')
+      expect(subject.class.dependencies[1][:version]).to eq('2.9.0')
+
+      expect(subject.class.dependencies[2][:name]).to eq('matplotlib')
+      expect(subject.class.dependencies[2][:version]).to eq('3.5.3')
+    end
   end
 
   describe Coursemology::Polyglot::Language::Python::Python3Point12 do
     it 'returns the correct display name' do
       expect(subject.class.display_name).to eq('Python 3.12')
+    end
+
+    it 'returns the correct dependency versions' do
+      expect(subject.class.dependencies[0][:name]).to eq('fnss')
+      expect(subject.class.dependencies[0][:version]).to eq('0.9.1')
+
+      expect(subject.class.dependencies[1][:name]).to eq('matplotlib')
+      expect(subject.class.dependencies[1][:version]).to eq('3.8.2')
+
+      expect(subject.class.dependencies[2][:name]).to eq('networkx')
+      expect(subject.class.dependencies[2][:version]).to eq('3.2.1')
     end
   end
 end

--- a/spec/coursemology/polyglot/language/r_spec.rb
+++ b/spec/coursemology/polyglot/language/r_spec.rb
@@ -6,5 +6,9 @@ RSpec.describe Coursemology::Polyglot::Language::R do
     it 'returns the correct display name' do
       expect(subject.class.display_name).to eq('R 4.1')
     end
+
+    it 'returns a nil docker image' do
+      expect(subject.class.docker_image).to be_nil
+    end
   end
 end


### PR DESCRIPTION
Added installed dependency data to default evaluators, based on data from the evaluator images.
- Python dependency versions were inspected using `pip freeze`
- Java and C++ dependency versions were taken from the respective Dockerfiles
- googletest version was generated by downloading the commit hash and running `git describe`, since their release documentation recommends building from source instead of checking out tagged versions